### PR TITLE
Refactor alarm button logic in title cards

### DIFF
--- a/hisnelmoslem/lib/src/core/di/dependency_injection.dart
+++ b/hisnelmoslem/lib/src/core/di/dependency_injection.dart
@@ -73,9 +73,7 @@ Future<void> initSL() async {
   sl.registerLazySingleton(() => ThemeCubit(sl()));
   sl.registerLazySingleton(() => AlarmsBloc(sl(), sl(), sl(), sl()));
   sl.registerLazySingleton(() => BookmarkBloc(sl(), sl()));
-  sl.registerLazySingleton(
-    () => HomeBloc(sl(), sl(), sl(), sl(), sl(), sl(), sl()),
-  );
+  sl.registerLazySingleton(() => HomeBloc(sl(), sl(), sl(), sl(), sl()));
   sl.registerLazySingleton(() => SearchCubit(sl()));
   sl.registerLazySingleton(() => SettingsCubit(sl(), sl(), sl(), sl(), sl()));
   sl.registerLazySingleton(() => AzkarFiltersCubit(sl()));

--- a/hisnelmoslem/lib/src/features/alarms_manager/presentation/components/title_card_alarm_button.dart
+++ b/hisnelmoslem/lib/src/features/alarms_manager/presentation/components/title_card_alarm_button.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hisnelmoslem/src/core/models/editor_result.dart';
+import 'package:hisnelmoslem/src/features/alarms_manager/data/models/alarm.dart';
+import 'package:hisnelmoslem/src/features/alarms_manager/presentation/components/alarm_editor.dart';
+import 'package:hisnelmoslem/src/features/alarms_manager/presentation/controller/bloc/alarms_bloc.dart';
+import 'package:hisnelmoslem/src/features/home/data/models/zikr_title.dart';
+
+class TitleCardAlarmButton extends StatelessWidget {
+  final DbTitle dbTitle;
+  const TitleCardAlarmButton({super.key, required this.dbTitle});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AlarmsBloc, AlarmsState>(
+      builder: (context, state) {
+        if (state is! AlarmsLoadedState) {
+          return const SizedBox.shrink();
+        }
+
+        final bool hasAlarm = state.alarms.any(
+          (element) => element.titleId == dbTitle.id,
+        );
+
+        if (!hasAlarm) {
+          return IconButton(
+            icon: const Icon(Icons.alarm_add_rounded),
+            onPressed: () async {
+              final EditorResult<DbAlarm>? result = await showAlarmEditorDialog(
+                context: context,
+                dbAlarm: DbAlarm(titleId: dbTitle.id, title: dbTitle.name),
+                isToEdit: false,
+              );
+
+              if (result == null) return;
+              if (!context.mounted) return;
+
+              context.read<AlarmsBloc>().add(AlarmsAddEvent(result.value));
+            },
+          );
+        }
+
+        final DbAlarm dbAlarm = state.alarms.firstWhere(
+          (element) => element.titleId == dbTitle.id,
+        );
+
+        return GestureDetector(
+          onLongPress: () async {
+            final EditorResult<DbAlarm>? result = await showAlarmEditorDialog(
+              context: context,
+              dbAlarm: dbAlarm,
+              isToEdit: true,
+            );
+
+            if (result == null) return;
+            if (!context.mounted) return;
+            switch (result.action) {
+              case EditorActionEnum.edit:
+                context.read<AlarmsBloc>().add(AlarmsEditEvent(result.value));
+              case EditorActionEnum.delete:
+                context.read<AlarmsBloc>().add(AlarmsRemoveEvent(result.value));
+              default:
+            }
+          },
+          child: dbAlarm.isActive
+              ? IconButton(
+                  icon: Icon(
+                    Icons.notifications_active,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  onPressed: () {
+                    context.read<AlarmsBloc>().add(
+                      AlarmsEditEvent(dbAlarm.copyWith(isActive: false)),
+                    );
+                  },
+                )
+              : IconButton(
+                  icon: const Icon(Icons.notifications_off),
+                  onPressed: () {
+                    context.read<AlarmsBloc>().add(
+                      AlarmsEditEvent(dbAlarm.copyWith(isActive: true)),
+                    );
+                  },
+                ),
+        );
+      },
+    );
+  }
+}

--- a/hisnelmoslem/lib/src/features/bookmark/presentation/screens/titles_bookmarks_screen.dart
+++ b/hisnelmoslem/lib/src/features/bookmark/presentation/screens/titles_bookmarks_screen.dart
@@ -22,10 +22,7 @@ class TitlesBookmarksScreen extends StatelessWidget {
                 title: S.of(context).nothingFoundInFavorites,
                 description: S.of(context).noTitleMarkedAsFavorite,
               )
-            : HomeTitlesListView(
-                titles: state.bookmarkedTitles,
-                alarms: state.alarms,
-              );
+            : HomeTitlesListView(titles: state.bookmarkedTitles);
       },
     );
   }

--- a/hisnelmoslem/lib/src/features/home/presentation/components/pages/titles_list_view.dart
+++ b/hisnelmoslem/lib/src/features/home/presentation/components/pages/titles_list_view.dart
@@ -1,27 +1,18 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/material.dart';
-import 'package:hisnelmoslem/src/features/alarms_manager/data/models/alarm.dart';
 import 'package:hisnelmoslem/src/features/home/data/models/zikr_title.dart';
 import 'package:hisnelmoslem/src/features/home/presentation/components/widgets/title_card.dart';
 
 class HomeTitlesListView extends StatelessWidget {
   final List<DbTitle> titles;
-  final Map<int, DbAlarm> alarms;
-  const HomeTitlesListView({
-    super.key,
-    required this.titles,
-    required this.alarms,
-  });
+  const HomeTitlesListView({super.key, required this.titles});
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       padding: const EdgeInsets.only(bottom: 100),
       itemBuilder: (context, index) {
-        return TitleCard(
-          dbTitle: titles[index],
-          dbAlarm: alarms[titles[index].id],
-        );
+        return TitleCard(dbTitle: titles[index]);
       },
       itemCount: titles.length,
     );

--- a/hisnelmoslem/lib/src/features/home/presentation/components/pages/titles_screen.dart
+++ b/hisnelmoslem/lib/src/features/home/presentation/components/pages/titles_screen.dart
@@ -26,12 +26,7 @@ class TitlesScreen extends StatelessWidget {
             : Column(
                 children: [
                   const TitleFreqFilterCard(),
-                  Expanded(
-                    child: HomeTitlesListView(
-                      titles: state.allTitles,
-                      alarms: state.alarms,
-                    ),
-                  ),
+                  Expanded(child: HomeTitlesListView(titles: state.allTitles)),
                 ],
               );
       },

--- a/hisnelmoslem/lib/src/features/home/presentation/components/widgets/title_card.dart
+++ b/hisnelmoslem/lib/src/features/home/presentation/components/widgets/title_card.dart
@@ -1,11 +1,8 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hisnelmoslem/src/core/extensions/extension.dart';
 import 'package:hisnelmoslem/src/core/extensions/extension_platform.dart';
-import 'package:hisnelmoslem/src/core/models/editor_result.dart';
-import 'package:hisnelmoslem/src/features/alarms_manager/data/models/alarm.dart';
-import 'package:hisnelmoslem/src/features/alarms_manager/presentation/components/alarm_editor.dart';
-import 'package:hisnelmoslem/src/features/alarms_manager/presentation/controller/bloc/alarms_bloc.dart';
+import 'package:hisnelmoslem/src/features/alarms_manager/presentation/components/title_card_alarm_button.dart';
 import 'package:hisnelmoslem/src/features/bookmark/presentation/components/bookmark_title_button.dart';
 import 'package:hisnelmoslem/src/features/home/data/models/zikr_title.dart';
 import 'package:hisnelmoslem/src/features/zikr_viewer/presentation/screens/zikr_viewer_screen.dart';
@@ -13,20 +10,11 @@ import 'package:hisnelmoslem/src/features/zikr_viewer/presentation/screens/zikr_
 class TitleCard extends StatelessWidget {
   final Color? titleColor;
   final DbTitle dbTitle;
-  final DbAlarm? dbAlarm;
 
-  const TitleCard({
-    super.key,
-    required this.dbTitle,
-    required this.dbAlarm,
-    this.titleColor,
-  });
+  const TitleCard({super.key, required this.dbTitle, this.titleColor});
 
   @override
   Widget build(BuildContext context) {
-    final DbAlarm alarm =
-        dbAlarm ?? DbAlarm(titleId: dbTitle.id, title: dbTitle.name);
-
     return ListTile(
       tileColor: titleColor,
       leading: Row(
@@ -48,78 +36,11 @@ class TitleCard extends StatelessWidget {
       ///TODO remove when desktop notification is ready
       trailing: PlatformExtension.isDesktop
           ? null
-          : _TitleCardAlarmButton(alarm: alarm, dbAlarm: dbAlarm),
+          : TitleCardAlarmButton(dbTitle: dbTitle),
       title: Text(dbTitle.name),
       onTap: () {
         context.push(ZikrViewerScreen(index: dbTitle.id));
       },
     );
-  }
-}
-
-class _TitleCardAlarmButton extends StatelessWidget {
-  final DbAlarm alarm;
-  final DbAlarm? dbAlarm;
-  const _TitleCardAlarmButton({required this.alarm, this.dbAlarm});
-
-  @override
-  Widget build(BuildContext context) {
-    return dbAlarm == null
-        ? IconButton(
-            icon: const Icon(Icons.alarm_add_rounded),
-            onPressed: () async {
-              final EditorResult<DbAlarm>? result = await showAlarmEditorDialog(
-                context: context,
-                dbAlarm: alarm,
-                isToEdit: false,
-              );
-
-              if (result == null) return;
-              if (!context.mounted) return;
-
-              context.read<AlarmsBloc>().add(AlarmsAddEvent(result.value));
-            },
-          )
-        : GestureDetector(
-            onLongPress: () async {
-              final EditorResult<DbAlarm>? result = await showAlarmEditorDialog(
-                context: context,
-                dbAlarm: alarm,
-                isToEdit: true,
-              );
-
-              if (result == null) return;
-              if (!context.mounted) return;
-              switch (result.action) {
-                case EditorActionEnum.edit:
-                  context.read<AlarmsBloc>().add(AlarmsEditEvent(result.value));
-                case EditorActionEnum.delete:
-                  context.read<AlarmsBloc>().add(
-                    AlarmsRemoveEvent(result.value),
-                  );
-                default:
-              }
-            },
-            child: alarm.isActive
-                ? IconButton(
-                    icon: Icon(
-                      Icons.notifications_active,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    onPressed: () {
-                      context.read<AlarmsBloc>().add(
-                        AlarmsEditEvent(alarm.copyWith(isActive: false)),
-                      );
-                    },
-                  )
-                : IconButton(
-                    icon: const Icon(Icons.notifications_off),
-                    onPressed: () {
-                      context.read<AlarmsBloc>().add(
-                        AlarmsEditEvent(alarm.copyWith(isActive: true)),
-                      );
-                    },
-                  ),
-          );
   }
 }

--- a/hisnelmoslem/lib/src/features/home/presentation/controller/bloc/home_event.dart
+++ b/hisnelmoslem/lib/src/features/home/presentation/controller/bloc/home_event.dart
@@ -28,15 +28,6 @@ class HomeSearchEvent extends HomeEvent {
   List<Object> get props => [searchText];
 }
 
-class HomeUpdateAlarmsEvent extends HomeEvent {
-  final List<DbAlarm> alarms;
-
-  const HomeUpdateAlarmsEvent({required this.alarms});
-
-  @override
-  List<Object> get props => [alarms];
-}
-
 class HomeToggleDrawerEvent extends HomeEvent {
   const HomeToggleDrawerEvent();
 }

--- a/hisnelmoslem/lib/src/features/home/presentation/controller/bloc/home_state.dart
+++ b/hisnelmoslem/lib/src/features/home/presentation/controller/bloc/home_state.dart
@@ -14,7 +14,6 @@ class HomeLoadedState extends HomeState {
   final List<int> dashboardArrangement;
   final List<DbTitle> titles;
   final List<int> bookmarkedTitlesIds;
-  final Map<int, DbAlarm> alarms;
   final List<DbContent> bookmarkedContents;
   final List<TitlesFreqEnum> freqFilters;
   final bool isSearching;
@@ -32,7 +31,6 @@ class HomeLoadedState extends HomeState {
   const HomeLoadedState({
     required this.dashboardArrangement,
     required this.titles,
-    required this.alarms,
     required this.bookmarkedContents,
     required this.freqFilters,
     required this.isSearching,
@@ -42,7 +40,6 @@ class HomeLoadedState extends HomeState {
   HomeLoadedState copyWith({
     List<int>? dashboardArrangement,
     List<DbTitle>? titles,
-    Map<int, DbAlarm>? alarms,
     List<DbContent>? bookmarkedContents,
     List<int>? bookmarkedTitlesIds,
     List<TitlesFreqEnum>? freqFilters,
@@ -51,7 +48,6 @@ class HomeLoadedState extends HomeState {
     return HomeLoadedState(
       dashboardArrangement: dashboardArrangement ?? this.dashboardArrangement,
       titles: titles ?? this.titles,
-      alarms: alarms ?? this.alarms,
       bookmarkedContents: bookmarkedContents ?? this.bookmarkedContents,
       freqFilters: freqFilters ?? this.freqFilters,
       isSearching: isSearching ?? this.isSearching,
@@ -63,7 +59,6 @@ class HomeLoadedState extends HomeState {
   List<Object> get props {
     return [
       titles,
-      alarms,
       isSearching,
       dashboardArrangement,
       freqFilters,

--- a/hisnelmoslem/lib/src/features/home_search/presentation/screens/home_search_screen.dart
+++ b/hisnelmoslem/lib/src/features/home_search/presentation/screens/home_search_screen.dart
@@ -20,18 +20,15 @@ class HomeSearchScreen extends StatelessWidget {
             }
             return state.searchedTitles.isEmpty
                 ? state.searchText.isEmpty
-                    ? const SizedBox()
-                    : Empty(
-                        isImage: false,
-                        icon: Icons.search_outlined,
-                        title:
-                            "${S.of(context).noTitleWithName}: ${state.searchText}",
-                        description: S.of(context).reviewIndexOfBook,
-                      )
-                : HomeTitlesListView(
-                    titles: state.searchedTitles,
-                    alarms: homeState.alarms,
-                  );
+                      ? const SizedBox()
+                      : Empty(
+                          isImage: false,
+                          icon: Icons.search_outlined,
+                          title:
+                              "${S.of(context).noTitleWithName}: ${state.searchText}",
+                          description: S.of(context).reviewIndexOfBook,
+                        )
+                : HomeTitlesListView(titles: state.searchedTitles);
           },
         );
       },


### PR DESCRIPTION
Moved alarm button logic from TitleCard to a new TitleCardAlarmButton widget. Removed alarm state management from HomeBloc and related classes, simplifying the HomeTitlesListView and TitleCard interfaces. This decouples alarm UI from the home state and streamlines alarm handling.